### PR TITLE
Remove js modules

### DIFF
--- a/android/app/src/main/java/com/enebattery/EneBatteryPackage.java
+++ b/android/app/src/main/java/com/enebattery/EneBatteryPackage.java
@@ -25,11 +25,6 @@ public class EneBatteryPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
The Js module registration is depricated from React Native version v0.47.2 [ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)